### PR TITLE
Fix fusion alignment file error (resolves #14)

### DIFF
--- a/transgene.py
+++ b/transgene.py
@@ -659,7 +659,8 @@ def main(params):
             os.remove(tumfile_path)
             os.remove(normfile_path)
 
-        # Temporary file used during fusion alignment steps
+    # Temporary file used during fusion alignment steps
+    if os.path.exists('transgene_fusion_alignments.pkl'):
         os.remove('transgene_fusion_alignments.pkl')
 
 


### PR DESCRIPTION
Checks if fusion alignment file exists before trying to remove it at the end of a run. 
Resolves #14 