### PR TITLE
Fix bug in snvs touching same codon (resolves #47)

### DIFF
--- a/src/transgene/core.py
+++ b/src/transgene/core.py
@@ -794,7 +794,7 @@ def correct_for_same_codon(snvs, mut_group):
                 logging.info('Merged (%s) into %s.', muts, merged_group)
                 # Now add this to the mutations dict
                 snvs[merged_group] = {'AA': {'REF': merged_group[0],
-                                             'ALT': merged_group[1],
+                                             'ALT': merged_group[-1],
                                              'POS': pos,
                                              'VAF': min([snvs[x]['AA']['VAF'] for x in mut_group])},
                                       'indel': False}


### PR DESCRIPTION
Resolves #47

TransGene now uses the correct index in the mutation to describe the ALT
allele